### PR TITLE
Add monitoring subsystem with vulnerable dependencies (SCA demo)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,100 @@
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>
         </dependency>
+
+        <!-- ==================================================================
+             Monitoring subsystem dependencies.
+
+             WARNING: every version pinned below is deliberately outdated and
+             carries publicly disclosed CVEs. They exist so this project has
+             realistic Software Composition Analysis (SCA) findings to report.
+             Do NOT deploy this application. Do NOT copy these coordinates into
+             a real project.
+             ================================================================== -->
+
+        <!-- Log4Shell. CVE-2021-44228 (CVSS 10.0), CVE-2021-45046,
+             CVE-2021-45105, CVE-2021-44832. Reached by AlertLoggingService. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
+        <!-- Text4Shell. CVE-2022-42889 (CVSS 9.8) via StringSubstitutor
+             interpolation. Reached by MetricTemplateService. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
+
+        <!-- Polymorphic deserialization gadget chains. CVE-2020-36518,
+             CVE-2019-20330, CVE-2019-16942, CVE-2019-16943, CVE-2019-14540.
+             Reached by SensorPayloadService. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.10.1</version>
+        </dependency>
+
+        <!-- Unsafe YAML constructor RCE. CVE-2022-1471 (CVSS 9.8),
+             CVE-2022-38752, CVE-2022-25857. Reached by MonitorConfigService. -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.30</version>
+        </dependency>
+
+        <!-- XML deserialization RCE. CVE-2021-39144 (CVSS 8.5),
+             CVE-2021-21344 and ~20 further RCE CVEs in the 1.4.x line.
+             Reached by DashboardStateService. -->
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.5</version>
+        </dependency>
+
+        <!-- InvokerTransformer deserialization RCE. CVE-2015-6420,
+             CVE-2015-7501. Note this is the exact artifact excluded from
+             apacheds-core, shared-ldap and hibernate-core above — declaring it
+             directly reintroduces the risk. Reached by ProbeRegistryService. -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+
+        <!-- Insecure temp directory creation. CVE-2020-8908, CVE-2023-2976,
+             CVE-2018-10237. Reached by HostCacheService. -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>24.1.1-jre</version>
+        </dependency>
+
+        <!-- JDBC URL abuse leading to RCE. CVE-2021-42392 (CVSS 9.8),
+             CVE-2022-23221, CVE-2018-10054. Reached by MetricsStoreService. -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.199</version>
+        </dependency>
+
+        <!-- Archive parsing DoS. CVE-2021-35515, CVE-2021-35516,
+             CVE-2021-35517, CVE-2021-36090. Reached by ArchiveImportService. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.20</version>
+        </dependency>
+
+        <!-- Stack exhaustion on deeply nested JSON. CVE-2023-1370,
+             CVE-2021-31684. Reached by QueryFilterService. -->
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.4.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/owasp/benchmark/service/monitoring/AlertLoggingService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/AlertLoggingService.java
@@ -1,0 +1,27 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Logs monitoring alerts through Log4j 2.14.1.
+ *
+ * <p>Dependency risk: Log4Shell (CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832).
+ * The alert text originates from the HTTP request and flows unmodified into the logger, so a
+ * {@code ${jndi:...}} lookup embedded in it is evaluated by the vulnerable runtime.
+ */
+public class AlertLoggingService {
+
+    private static final Logger LOG = LogManager.getLogger(AlertLoggingService.class);
+
+    public void recordAlert(String alertText) {
+        // Tainted value interpolated by Log4j's message lookups.
+        LOG.error("Monitoring alert received: {}", alertText);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/ArchiveImportService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/ArchiveImportService.java
@@ -1,0 +1,37 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+
+/**
+ * Imports uploaded metric archives through Apache Commons Compress 1.20.
+ *
+ * <p>Dependency risk: archive-parsing denial of service (CVE-2021-35515, CVE-2021-35516,
+ * CVE-2021-35517, CVE-2021-36090). A crafted archive drives excessive CPU/memory allocation while
+ * the entries are enumerated below.
+ */
+public class ArchiveImportService {
+
+    public List<String> listEntries(byte[] archive) throws IOException {
+        List<String> names = new ArrayList<>();
+        // Tainted bytes parsed by the vulnerable archive reader.
+        try (ZipArchiveInputStream in =
+                new ZipArchiveInputStream(new ByteArrayInputStream(archive))) {
+            ZipArchiveEntry entry;
+            while ((entry = in.getNextZipEntry()) != null) {
+                names.add(entry.getName());
+            }
+        }
+        return names;
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/DashboardStateService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/DashboardStateService.java
@@ -1,0 +1,26 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import com.thoughtworks.xstream.XStream;
+
+/**
+ * Restores saved dashboard layouts through XStream 1.4.5.
+ *
+ * <p>Dependency risk: XML deserialization remote code execution (CVE-2021-39144, CVE-2021-21344 and
+ * roughly twenty further RCE CVEs in the 1.4.x line). No security framework / allow-list is
+ * configured, so {@link XStream#fromXML(String)} on untrusted XML instantiates arbitrary types.
+ */
+public class DashboardStateService {
+
+    private final XStream xstream = new XStream();
+
+    public Object restore(String xml) {
+        // Tainted XML deserialized with no type allow-list.
+        return xstream.fromXML(xml);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/HostCacheService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/HostCacheService.java
@@ -1,0 +1,25 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import com.google.common.io.Files;
+import java.io.File;
+
+/**
+ * Allocates scratch directories for cached host metrics through Guava 24.1.1-jre.
+ *
+ * <p>Dependency risk: insecure temporary directory creation (CVE-2020-8908) plus further CVEs in
+ * this Guava line (CVE-2023-2976, CVE-2018-10237). {@link Files#createTempDir()} creates a
+ * world-readable directory with predictable permissions.
+ */
+public class HostCacheService {
+
+    public File allocateCacheDir() {
+        // Vulnerable temp-directory factory.
+        return Files.createTempDir();
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/MetricTemplateService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/MetricTemplateService.java
@@ -1,0 +1,25 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import org.apache.commons.text.StringSubstitutor;
+
+/**
+ * Renders metric label templates through Apache Commons Text 1.9.
+ *
+ * <p>Dependency risk: Text4Shell (CVE-2022-42889). The default {@link StringSubstitutor} resolves
+ * {@code ${script:...}}, {@code ${dns:...}} and {@code ${url:...}} lookups, so an attacker-supplied
+ * template string reaches code execution.
+ */
+public class MetricTemplateService {
+
+    public String render(String template) {
+        StringSubstitutor substitutor = new StringSubstitutor();
+        // Tainted template interpolated with the dangerous default lookups enabled.
+        return substitutor.replace(template);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/MetricsStoreService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/MetricsStoreService.java
@@ -1,0 +1,35 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Opens the embedded metrics database through the H2 1.4.199 driver.
+ *
+ * <p>Dependency risk: JDBC URL abuse leading to RCE (CVE-2021-42392, CVE-2022-23221) and
+ * information disclosure (CVE-2018-10054). The attacker-controlled fragment is concatenated into
+ * the JDBC URL, where an {@code INIT=...} clause runs arbitrary SQL/Java at connection time.
+ */
+public class MetricsStoreService {
+
+    static {
+        try {
+            Class.forName("org.h2.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("H2 driver missing", e);
+        }
+    }
+
+    public Connection openStore(String urlFragment) throws SQLException {
+        // Tainted fragment concatenated into the JDBC URL (enables the INIT vector).
+        String url = "jdbc:h2:mem:metrics;" + urlFragment;
+        return DriverManager.getConnection(url, "sa", "");
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/MonitorConfigService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/MonitorConfigService.java
@@ -1,0 +1,24 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Loads monitor configuration through SnakeYAML 1.30.
+ *
+ * <p>Dependency risk: unsafe YAML construction (CVE-2022-1471, CVE-2022-38752, CVE-2022-25857). The
+ * default {@link Yaml} constructor honours {@code !!} type tags, so an attacker-supplied document
+ * can instantiate arbitrary classes.
+ */
+public class MonitorConfigService {
+
+    public Object loadConfig(String yaml) {
+        // Tainted document parsed with the unsafe default constructor.
+        return new Yaml().load(yaml);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/ProbeRegistryService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/ProbeRegistryService.java
@@ -1,0 +1,41 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections.functors.InvokerTransformer;
+import org.apache.commons.collections.map.TransformedMap;
+
+/**
+ * Keeps a registry of active monitoring probes, keyed through Commons Collections 3.2.1.
+ *
+ * <p>Dependency risk: {@code InvokerTransformer} deserialization gadget (CVE-2015-6420,
+ * CVE-2015-7501). This is the exact artifact excluded from {@code apacheds-core}, {@code
+ * shared-ldap} and {@code hibernate-core} in the POM; declaring it directly and wiring a {@link
+ * TransformedMap} around {@link InvokerTransformer} reintroduces the gadget on the classpath.
+ */
+@SuppressWarnings("unchecked")
+public class ProbeRegistryService {
+
+    private final Map<String, Object> probes;
+
+    public ProbeRegistryService() {
+        Transformer transformer = new InvokerTransformer("toString", new Class[0], new Object[0]);
+        this.probes = TransformedMap.decorate(new HashMap(), null, transformer);
+    }
+
+    public void register(String probeName, Object descriptor) {
+        // Value passes through the InvokerTransformer gadget on insertion.
+        probes.put(probeName, descriptor);
+    }
+
+    public int size() {
+        return probes.size();
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/QueryFilterService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/QueryFilterService.java
@@ -1,0 +1,25 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
+
+/**
+ * Parses dashboard query filters through json-smart 2.4.7.
+ *
+ * <p>Dependency risk: stack exhaustion / denial of service on deeply nested JSON (CVE-2023-1370,
+ * CVE-2021-31684). The untrusted filter expression is parsed with no depth limit.
+ */
+public class QueryFilterService {
+
+    public Object parseFilter(String filter) throws ParseException {
+        JSONParser parser = new JSONParser(JSONParser.MODE_PERMISSIVE);
+        // Tainted expression parsed without a nesting-depth guard.
+        return parser.parse(filter);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/service/monitoring/SensorPayloadService.java
+++ b/src/main/java/org/owasp/benchmark/service/monitoring/SensorPayloadService.java
@@ -1,0 +1,33 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this class deliberately reaches a vulnerable third-party API on untrusted input so
+ * that Software Composition Analysis reports a reachable dependency risk. Do not deploy.
+ */
+package org.owasp.benchmark.service.monitoring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+
+/**
+ * Parses sensor payloads through jackson-databind 2.9.10.1.
+ *
+ * <p>Dependency risk: polymorphic deserialization gadget chains (CVE-2020-36518, CVE-2019-20330,
+ * CVE-2019-16942, CVE-2019-16943, CVE-2019-14540). Default typing is enabled and the untrusted JSON
+ * is bound to {@link Object}, allowing an attacker to instantiate gadget classes by type hint.
+ */
+@SuppressWarnings("deprecation")
+public class SensorPayloadService {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public SensorPayloadService() {
+        // The setting that makes gadget-chain deserialization possible.
+        mapper.enableDefaultTyping();
+    }
+
+    public Object parsePayload(String json) throws IOException {
+        // Tainted JSON deserialized with polymorphic typing.
+        return mapper.readValue(json, Object.class);
+    }
+}

--- a/src/main/java/org/owasp/benchmark/web/MonitoringServlet.java
+++ b/src/main/java/org/owasp/benchmark/web/MonitoringServlet.java
@@ -1,0 +1,97 @@
+/**
+ * JMonitoringAppSC - monitoring subsystem.
+ *
+ * <p>WARNING: this servlet feeds untrusted HTTP input straight into the monitoring services, each
+ * of which reaches a known-vulnerable dependency. It exists so Software Composition Analysis has a
+ * realistic HTTP entry point to report reachable dependency risks against. Do not deploy.
+ *
+ * <p>Layering: this is a Presentation-tier component (package {@code ...web}) and only depends on
+ * the Business tier (package {@code ...service.monitoring}), per architecture.json.
+ */
+package org.owasp.benchmark.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.owasp.benchmark.service.monitoring.AlertLoggingService;
+import org.owasp.benchmark.service.monitoring.ArchiveImportService;
+import org.owasp.benchmark.service.monitoring.DashboardStateService;
+import org.owasp.benchmark.service.monitoring.HostCacheService;
+import org.owasp.benchmark.service.monitoring.MetricTemplateService;
+import org.owasp.benchmark.service.monitoring.MetricsStoreService;
+import org.owasp.benchmark.service.monitoring.MonitorConfigService;
+import org.owasp.benchmark.service.monitoring.ProbeRegistryService;
+import org.owasp.benchmark.service.monitoring.QueryFilterService;
+import org.owasp.benchmark.service.monitoring.SensorPayloadService;
+
+@WebServlet(value = "/monitoring/dispatch")
+public class MonitoringServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/plain;charset=UTF-8");
+        PrintWriter out = response.getWriter();
+
+        String action = request.getParameter("action");
+        String payload = request.getParameter("payload");
+        if (action == null) {
+            action = "";
+        }
+        if (payload == null) {
+            payload = "";
+        }
+
+        try {
+            switch (action) {
+                case "alert":
+                    new AlertLoggingService().recordAlert(payload);
+                    out.println("alert logged");
+                    break;
+                case "template":
+                    out.println(new MetricTemplateService().render(payload));
+                    break;
+                case "sensor":
+                    out.println(new SensorPayloadService().parsePayload(payload));
+                    break;
+                case "config":
+                    out.println(new MonitorConfigService().loadConfig(payload));
+                    break;
+                case "dashboard":
+                    out.println(new DashboardStateService().restore(payload));
+                    break;
+                case "probe":
+                    ProbeRegistryService registry = new ProbeRegistryService();
+                    registry.register(payload, payload);
+                    out.println("probes: " + registry.size());
+                    break;
+                case "cache":
+                    out.println(new HostCacheService().allocateCacheDir().getAbsolutePath());
+                    break;
+                case "store":
+                    new MetricsStoreService().openStore(payload).close();
+                    out.println("store opened");
+                    break;
+                case "archive":
+                    out.println(
+                            new ArchiveImportService()
+                                    .listEntries(payload.getBytes("UTF-8")));
+                    break;
+                case "filter":
+                    out.println(new QueryFilterService().parseFilter(payload));
+                    break;
+                default:
+                    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    out.println("unknown action");
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a **monitoring subsystem** whose whole purpose is to give SonarQube realistic **Software Composition Analysis (dependency-risk)** findings. Ten dependencies are pinned to versions with publicly disclosed CVEs, and each is **actually reached on untrusted HTTP input**, so the risks are reported as *reachable* rather than merely present.

⚠️ Intentionally insecure demo code — **do not deploy**.

## Dependencies added to `pom.xml`
| Artifact | Version | CVE highlights |
|---|---|---|
| `log4j-core` | 2.14.1 | Log4Shell — CVE-2021-44228, -45046, -45105, -44832 |
| `commons-text` | 1.9 | Text4Shell — CVE-2022-42889 |
| `jackson-databind` | 2.9.10.1 | polymorphic deserialization — CVE-2020-36518, CVE-2019-20330, … |
| `snakeyaml` | 1.30 | unsafe constructor — CVE-2022-1471, -38752, -25857 |
| `xstream` | 1.4.5 | XML deserialization RCE — CVE-2021-39144, CVE-2021-21344, … |
| `commons-collections` | 3.2.1 | InvokerTransformer gadget — CVE-2015-6420, -7501 |
| `guava` | 24.1.1-jre | insecure temp dir — CVE-2020-8908, CVE-2023-2976 |
| `h2` | 1.4.199 | JDBC URL RCE — CVE-2021-42392, CVE-2022-23221 |
| `commons-compress` | 1.20 | archive-parsing DoS — CVE-2021-35515…36090 |
| `json-smart` | 2.4.7 | deeply-nested JSON DoS — CVE-2023-1370, CVE-2021-31684 |

Note: `commons-collections:3.2.1` is the exact artifact that was *excluded* from `apacheds-core`, `shared-ldap` and `hibernate-core`; declaring it directly reintroduces the gadget on the classpath.

## Reachability
`org.owasp.benchmark.web.MonitoringServlet` (`POST /monitoring/dispatch`) routes the request `payload` parameter to one of ten Business-tier services under `org.owasp.benchmark.service.monitoring`, each of which invokes the corresponding vulnerable API on that tainted input.

## Architecture
Respects `architecture.json`: the Presentation-tier servlet depends only on the Business-tier services; no Presentation→Data dependency is introduced.

## Verification
New sources compile with `--release 8` against the pinned dependency versions. (A full `mvn compile` is blocked locally by the pre-existing, unrelated `shared-ldap:1.0.0-M13` artifact that is not in Maven Central — CI resolves it from its own cache.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)